### PR TITLE
Fix overlap of heavyCommandModules node

### DIFF
--- a/EngTechTree.cfg
+++ b/EngTechTree.cfg
@@ -117,7 +117,7 @@
 		nodeName = node3_heavyCommandModules
 		anyToUnlock = True
 		icon = RDicon_commandmodules
-		pos = -2408,924,-10
+		pos = -2400,1075,-10
 		scale = 0.6
 		Parent
 		{


### PR DESCRIPTION
The "Heavy Command Modules" node was almost at the same position as the "Logistics and Landing Modules". Moved it two steps up.
