### PR TITLE
Medium aviation patch

### DIFF
--- a/GameData/ETT/EngTechTree.cfg
+++ b/GameData/ETT/EngTechTree.cfg
@@ -32,6 +32,8 @@ TechTree
 			part = proceduralTankKethane
 			part = KA_Tank_125_04
 			part = SXTBalloon
+			part = SXTBalloonGold
+			part = SXTBalloon375
 		}
 	}
 	RDNode
@@ -91,6 +93,8 @@ TechTree
 			part = KA_Tank_125_03
 			part = LargeTank
 			part = KER_Tank
+			part = SXTBalloonGoldB
+			part = SXTBalloonGoldB375
 		}
 	}
 	RDNode
@@ -253,7 +257,6 @@ TechTree
 			part = LBSI-NG1v5
 			part = WBI_Mole18
 			part = WBI_Brumby
-			part = SXTSPKTRCabin
 		}
 	}
 	RDNode
@@ -372,6 +375,7 @@ TechTree
 			part = A2Reactor
 			part = reactor-25-2
 			part = USI_Nuke_250
+			part = M2X_Reactor
 		}
 	}
 	RDNode
@@ -404,6 +408,7 @@ TechTree
 			part = taurusNuclearEngine
 			part = TweakableThermalTurbojet
 			part = SXTNERVA
+			part = M2X_Pluto
 		}
 	}
 	RDNode
@@ -576,6 +581,9 @@ TechTree
 			part = SXTDLK83EHabitat
 			part = SXTISSHabISK30
 			part = SXTPipeGLong
+			part = M3X_THub
+			part = M3X_XHub
+			part = M3X_CyclopsCockpit
 		}
 	}
 	RDNode
@@ -700,6 +708,7 @@ TechTree
 			part = KER_Shelter
 			part = STXCANIOT
 			part = SXTCrewCabSSP20
+			part = kapcubehabitat
 		}
 	}
 	RDNode
@@ -826,6 +835,13 @@ TechTree
 			part = SXTOsualRadHull
 			part = SXTOsualRadHullEnd
 			part = SXTadapterSize3Mk3
+			part = M3X_LongChine
+			part = SXTWingVeryLarge
+			part = SXTmk3CargoBayRamp
+			part = M3X_LongSegment
+			part = M3X_SubsonicIntake
+			part = M3X_Mk2Tricoupler
+			part = M3X_serviceBay
 		}
 	}
 	RDNode
@@ -880,44 +896,30 @@ TechTree
 		}
 		Unlocks
 		{
-			part = SeatHDCommand
-			part = FSfighterWing
-			part = FStailWing
-			part = FSwinglet
-			part = FSfighterCockpit
-			part = FSnoseEngine
-			part = FSairTank
-			part = FSdropTank
-			part = FSdropTankMount
-			part = FSoblongFuselageHalf
-			part = FSoblongNose
-			part = FSoblongNoseLong
-			part = FSoblongNoseRound
-			part = FSoblongTail
-			part = FSoblongToRoundAdapter
-			part = FSoblongToSmallAdapter
-			part = FSengineMount
-			part = FSfighterLandingGear
-			part = FSfighterTailGear
-			part = KAXsportprop
 			part = NBintakeBasic0m
 			part = NBjetBasic0m
 			part = NB0mtankJet1
 			part = MK1LFOFuselage
 			part = size0PulseJet
-			part = miniJetEngine
-			part = miniFuselage
 			part = GearFixed
 			part = miniIntake
 			part = MK1Fuselage
-			part = Mk1FuselageStructural
 			part = wingConnector5
 			part = smallCtrlSrf
-			part = Mark1Cockpit
 			part = structuralWing4
 			part = GearFree
-			part = SXTWingSmall
-			part = SXTWingSmallHalf
+			part = FSbiPlaneWingCenter
+			part = FSbiPlaneWingMain
+			part = FSbiPlaneWingRound
+			part = FSbiPlaneWingShort
+			part = FSbiPlaneWingTip
+			part = FSbiPlaneTail
+			part = SXTBuzzard
+			part = FSbiplaneCockpit
+			part = Mark1Cockpit
+			part = Mk1FuselageStructural
+			part = SXTTinyprop
+			part = miniJetEngine
 		}
 	}
 	RDNode
@@ -1022,6 +1024,7 @@ TechTree
 			part = SXT625mFuel4
 			part = SXTAJ10Mid
 			part = SXTAJ10
+			part = SXTCargoBay1
 		}
 	}
 	RDNode
@@ -1175,6 +1178,9 @@ TechTree
 			part = RAPIER
 			part = KER_SABRE
 			part = SXTLANCER
+			part = M2X_ESTOC
+			part = M2X_MATTOCK
+			part = M3X_CLEAVER
 		}
 	}
 	RDNode
@@ -1201,6 +1207,11 @@ TechTree
 			part = wingShuttleStrake
 			part = wingShuttleDelta
 			part = airlinerMainWing
+			part = M3X_WingA
+			part = M3X_WingB
+			part = M3X_WingC
+			part = M3X_WingD
+			part = M3X_Wingboard
 		}
 	}
 	RDNode
@@ -1247,8 +1258,9 @@ TechTree
 			part = MK1IntakeFuselage
 			part = IntakeRadialLong
 			part = B9_Engine_SABRE_Intake_S
-			part = SXTInlineAirIntakeTLarge
 			part = SXTInlineAirIntake
+			part = LRadialAirIntake
+			part = FSoblongNoseIntake
 		}
 	}
 	RDNode
@@ -1272,7 +1284,6 @@ TechTree
 		}
 		Unlocks
 		{
-			part = Typhoon Cockpit
 			part = B9_Aero_HL_Body_Structure_1m_U
 			part = B9_Aero_HL_Adapter_2m_Side
 			part = B9_Aero_HL_Body_Structure_2m_A
@@ -1301,7 +1312,8 @@ TechTree
 			part = mk2FuselageLongLFO
 			part = mk2CrewCabin
 			part = mk2CargoBayL
-			part = SXTEntenteCordiale
+			part = M3X_ShovelCockpit
+			part = M2X_AeroIntake
 		}
 	}
 	RDNode
@@ -1328,6 +1340,8 @@ TechTree
 			part = FSapacheLandingGearFlip
 			part = GearMedium
 			part = GearSmall
+			part = M2X_RadialLeg
+			part = FSbomberLandingGear
 		}
 	}
 	RDNode
@@ -1513,7 +1527,6 @@ TechTree
 			part = sensorBarometer
 			part = longAntenna
 			part = parachuteRadial
-			part = SXTTinyprop
 			part = SR_Battery
 			part = SR_LaunchStick
 			part = SR_Nosecone_35
@@ -1525,6 +1538,8 @@ TechTree
 			part = adapterSmallMiniShort
 			part = trussPiece1x
 			part = RTShortAntenna1
+			part = SXTSputnik
+			part = SXTSputnic
 		}
 	}
 	RDNode
@@ -1579,26 +1594,6 @@ TechTree
 		}
 		Unlocks
 		{
-			part = InlinePassengerCan
-			part = FSbiPlaneAileron
-			part = FSbiplaneCockpit
-			part = FSbiPlaneElevator
-			part = FSbiPlaneRudder
-			part = FSbiPlaneSkid
-			part = FSbiPlaneTail
-			part = FSbiPlaneWheelPair
-			part = FSbiPlaneWingCenter
-			part = FSbiPlaneWingMain
-			part = FSbiPlaneWingRound
-			part = FSbiPlaneWingShort
-			part = FSbiPlaneWingTip
-			part = FSstrutConnectorWire
-			part = FSstrutConnectorWood
-			part = FSPROpeller
-			part = FSPROpellerElectric
-			part = FSoblongMultiTank
-			part = FSbattery
-			part = FSbiplaneGear
 			part = KA_AtmScoop_125_01
 			part = KA_AtmScoop_250_01
 			part = KA_Jet_Radial_01
@@ -1609,8 +1604,20 @@ TechTree
 			part = LFKA_Jet_Stack_01
 			part = Mark2Cockpit
 			part = noseConeAdapter
-			part = SXTBuzzard
+			part = kap1x05spoiler1
+			part = FSoblongToRoundAdapter
+			part = FSoblongNoseRound
+			part = FSoblongToSmallAdapter
+			part = FSoblongNoseLong
+			part = FSoblongFuselageHalf
+			part = FSoblongNose
+			part = FSoblongTail
+			part = FSfighterCockpit
 			part = SXTClyde
+			part = SeatHDCommand
+			part = FSoblongMultiTank
+			part = MK1CrewCabin
+			part = InlinePassengerCan
 		}
 	}
 	RDNode
@@ -1649,6 +1656,12 @@ TechTree
 			part = USI_Airbag_Single_01
 			part = SmallGearBay
 			part = MKS_LandingWheel_Side
+			part = FSlandingPads
+			part = FSfighterTailGear
+			part = FSbiplaneGear
+			part = FSbiPlaneSkid
+			part = FSfighterLandingGear
+			part = FSbiPlaneWheelPair
 		}
 	}
 	RDNode
@@ -1729,6 +1742,8 @@ TechTree
 			part = KsatGirderRound
 			part = KsatGirderTri
 			part = dmUSAtmosSense
+			part = SXTtruckbox
+			part = AirEnabledKASBoatAnchorIV
 		}
 	}
 	RDNode
@@ -1815,7 +1830,6 @@ TechTree
 			part = lightstrobe_white
 			part = B9_Utility_Light_N1_White
 			part = FASAGeminiPodLight
-			part = FSnoseEngineElectric
 			part = JSIPrimitiveExternalCamera
 			part = capacitor-0625
 			part = proceduralBattery
@@ -1925,6 +1939,7 @@ TechTree
 			part = KA_SRB_625_01
 			part = SXTWaxWing
 			part = SXTCastor30
+			part = RATObottle
 		}
 	}
 	RDNode
@@ -1961,6 +1976,7 @@ TechTree
 			part = SmallFlatRadiator
 			part = 1.25_Heatshield
 			part = B9_Engine_SABRE_S_Body
+			part = SXTHeatShieldSize0
 		}
 	}
 	RDNode
@@ -2035,12 +2051,9 @@ TechTree
 			part = RLA_small_probe_4sides
 			part = probeCoreCube
 			part = probeCoreOcto
-			part = SXTSputnik
 			part = SR_InlineProbe
 			part = kOSMachineRad
 			part = KsatComRound
-			part = SXTSputnic
-			part = truss-octo-drone-01
 		}
 	}
 	RDNode
@@ -2121,6 +2134,7 @@ TechTree
 			part = TLV_Fairing_A
 			part = TLV_Fairing_B
 			part = OKS_Cap
+			part = SXTfairingSize0
 		}
 	}
 	RDNode
@@ -2149,7 +2163,6 @@ TechTree
 			part = xluzopl
 			part = B9_Utility_Light_A1_White
 			part = B9_Utility_Light_N1_Large_White
-			part = KAXelectricprop
 			part = KWRadBattSmallS
 			part = capacitor-rad-0625-2
 			part = KKAOSS_LS_container_carbon_extractor
@@ -2160,6 +2173,7 @@ TechTree
 			part = Cherry Light
 			part = MKS_LightGlobe
 			part = WBI_PlasmaTV3
+			part = FSbattery
 		}
 	}
 	RDNode
@@ -2183,16 +2197,10 @@ TechTree
 		}
 		Unlocks
 		{
-			part = FSswampEngine
-			part = FSfloatEnd
-			part = FSfloatEndTail
-			part = FSfloatGearbay
-			part = FSfloatStraight
-			part = FSfloatStrut
-			part = fsmovecraftgadget
-			part = KAXradialprop
 			part = SR_Gridfin_03
 			part = SXTKO211Dprop
+			part = SXTKO211prop
+			part = FSPROpeller
 		}
 	}
 	RDNode
@@ -2219,30 +2227,19 @@ TechTree
 			part = FSbomberWing
 			part = FSbomberWingExtender
 			part = FStailWingLarge
-			part = FSbomberCockpit
-			part = FSlancasterEngineGear
-			part = FSlancasterEngine
-			part = FSbombBay
-			part = FSbomberFuselage
-			part = FSbomberFuselageTail
-			part = FSCrewFuselage
-			part = FSbomberLandingGear
-			part = KAXmedCockpit
-			part = KAXmedFuselage
-			part = KAXmedJetFuel
-			part = KAXmedTail
-			part = KAXturboprop
 			part = NBpylonAero0
 			part = NBpylonAero1
 			part = NBpylonAero2
-			part = structuralPylon
 			part = wingConnector
 			part = structuralWing
 			part = sweptWing1
 			part = sweptWing2
 			part = wingConnector2
 			part = structuralWing2
-			part = SXTke111
+			part = SXTengineattachment
+			part = FSfighterJetWing
+			part = B9_Aero_Wing_Procedural_TypeA
+			part = structuralPylon
 		}
 	}
 	RDNode
@@ -2266,7 +2263,6 @@ TechTree
 		}
 		Unlocks
 		{
-			part = KN2Cabin
 			part = B9_Structure_R0_Railing
 			part = B9_Structure_R1_Railing
 			part = B9_Structure_R2_Railing
@@ -2287,6 +2283,23 @@ TechTree
 			part = NBadapter3x7
 			part = airplaneTail
 			part = airplaneTailB
+			part = Mk1Chinecap
+			part = Mk1ChineLong
+			part = Mk1ChineShort
+			part = 25mKossak
+			part = LMkIIAircaftTail
+			part = SXTsize2LFtankShort
+			part = SXTsize2LFtank
+			part = KAXmedFuselage
+			part = KAXmedTail
+			part = FSbombBay
+			part = KAXmedCockpit
+			part = KAXmedJetFuel
+			part = LMkIIAircaftTail
+			part = LMkIIIAircaftFus
+			part = LMkIIIAircaftFusLong
+			part = LMkIIAircaftFusLong
+			part = LMkIIAircaftFus
 		}
 	}
 	RDNode
@@ -2477,9 +2490,6 @@ TechTree
 			part = USI_Radial_Float_Sm
 			part = miniLandingLeg
 			part = SXTAirbagSmall
-			part = SXTfloatFront
-			part = SXTfloatMid
-			part = SXTfloatOutboard
 		}
 	}
 	RDNode
@@ -2529,6 +2539,9 @@ TechTree
 			part = WBI_Buckboard
 			part = WBI_Buckboard2
 			part = SXTtruckfueltank
+			part = FSdropTankMount
+			part = FSairTank
+			part = FSdropTank
 		}
 	}
 	RDNode
@@ -2585,7 +2598,6 @@ TechTree
 			part = rcsTankRadialLong
 			part = linearRcs
 			part = RCSBlock
-			part = SXTKO211prop
 			part = TLV_Vernier
 			part = tankSmallCapRCS
 			part = SR_Gyroscope
@@ -2632,15 +2644,10 @@ TechTree
 			part = NP_nosecone_125m_FuelTankCap
 			part = NP_nosecone_125m_small
 			part = NP_sas_125m
-			part = 625mBonny
-			part = SXTClyde
-			part = LMiniAircaftTail
-			part = SXTBuzzard
-			part = SXTMiniJet
-			part = SXTtruckcabinsmall
-			part = SXTtruckcabin
 			part = SR_Wing_01
 			part = winglet
+			part = FSstrutConnectorWire
+			part = FSstrutConnectorWood
 		}
 	}
 	RDNode
@@ -2687,6 +2694,7 @@ TechTree
 			part = CLV_Nose_A
 			part = CXA_NodeCoverV1
 			part = CXA_NodeCoverV2
+			part = sxtshroudradialhardpoint
 		}
 	}
 	RDNode
@@ -2764,7 +2772,6 @@ TechTree
 			part = NBdockingHelper0
 			part = habTech_APAS
 			part = habTech_CBM
-			part = SXTWingLarge
 			part = WBI_Mk1RadialDockingPort
 			part = WBI_Mk1DockingPort
 		}
@@ -2965,6 +2972,8 @@ TechTree
 			part = WBI_Fulcrum
 			part = SXTLT80
 			part = SXTMk2LinearAerospike
+			part = M2X_AugmentedRocket
+			part = M2X_LinearAerospike
 		}
 	}
 	RDNode
@@ -3026,8 +3035,6 @@ TechTree
 		Unlocks
 		{
 			part = kap1x05to250tanker
-			part = kapcub1x05biadapt
-			part = kapcubearch
 			part = B9_Structure_SN_Strut
 			part = BAEquadcoupler10m
 			part = BAEquadcoupler2m
@@ -3070,6 +3077,8 @@ TechTree
 			part = KA_LandingFrame_4
 			part = SXTTriangleRightangle
 			part = SXTTriHexagon
+			part = SXTtruckrear
+			part = SXTtruckrearSmall
 		}
 	}
 	RDNode
@@ -3097,11 +3106,6 @@ TechTree
 			part = B9_Aero_Intake_CLR
 			part = B9_Cockpit_MK2_Bicoupler_S
 			part = B9_Cockpit_MK2_Body_Crew_2m
-			part = FSfighterJetElevator
-			part = FSfighterJetRudder
-			part = FSfighterJetWing
-			part = FSoblongNoseIntake
-			part = FSoblongTailJet
 			part = mk2Cockpit_Standard
 			part = adapterSize2-Mk2
 			part = mk2SpacePlaneAdapter
@@ -3109,9 +3113,22 @@ TechTree
 			part = mk2FuselageShortLFO
 			part = SXTEntenteCordiale
 			part = SXTmk2cargoadapter
-			part = LMkIIAircaftTail
-			part = SXTsize2LFtankShort
-			part = SXTsize2LFtank
+			part = M2X_ChineCap
+			part = M2X_ChineShort
+			part = M2X_RootChineShort
+			part = M2X_EngineShroud
+			part = M2X_Tailboom
+			part = SXTMk2FuselageStructural
+			part = M2X_SupersonicNose
+			part = M2X_MantaIntake
+			part = M2X_InlineIntake
+			part = M2X_TunaCockpit
+			part = M2X_RavenCockpit
+			part = M2X_ViperCockpit
+			part = M2X_Decoupler
+			part = M2X_DropshipCockpit
+			part = M2X_SmallLab
+			part = M2X_Shortbicoupler
 		}
 	}
 	RDNode
@@ -3165,6 +3182,8 @@ TechTree
 			part = SXTPipeLong
 			part = SXTmk2225degree
 			part = RSBstrutXL
+			part = kapcub1x05biadapt
+			part = kapcubebicoupler
 		}
 	}
 	RDNode
@@ -3215,7 +3234,6 @@ TechTree
 			part = LBSI-Kappa-NK1-2
 			part = LBSI-Kappa-NK2
 			part = WBI_Backseat
-			part = ringcmdpodMk1001bis
 		}
 	}
 	RDNode
@@ -3258,9 +3276,6 @@ TechTree
 			part = NP_OdinCapsule2W
 			part = RLA_tiny_torque_radial
 			part = sasModule
-			part = 25mKossak
-			part = LprobeFoil
-			part = SXTRCSRack
 		}
 	}
 	RDNode
@@ -3284,7 +3299,6 @@ TechTree
 		}
 		Unlocks
 		{
-			part = kapcubebicoupler
 			part = BAEbicoupler10m
 			part = BAEbicoupler2m
 			part = BAEbicoupler3m
@@ -3313,20 +3327,13 @@ TechTree
 			part = SYSRBconeSize2slanted
 			part = SYSRBconeSize3
 			part = SYSRBconeSize3slanted
-			part = SXTCargoBay1
-			part = LMkIAircaftFus
-			part = LMkIIAircaftTail
-			part = LMkIIIAircaftFusLong
-			part = LMkIIIAircaftFus
-			part = SXTOsualHullLarge
-			part = SXTOsualTailLarge
 			part = US_1R110_Wedge_KISContainer
 			part = KKAOSS_base_bicupler
 			part = MKV_AnchorHub
 			part = MKV_BallHub
 			part = MKS_375_OCTO
 			part = USI_MDS
-			part = SXTCargoBay1
+			part = kapcubearch
 		}
 	}
 	RDNode
@@ -3521,7 +3528,6 @@ TechTree
 			part = FScopterRotorMainElectric
 			part = FScopterRotorTail
 			part = FStailBoom
-			part = FSlandingPads
 			part = KAXkueyEngine
 			part = KAXkueyTailRotor
 			part = SXTmeadowlark
@@ -3713,6 +3719,12 @@ TechTree
 			part = SXTelevonLarge
 			part = SXTAirbrakeLarge
 			part = SXTn1GridFin
+			part = FSfighterJetElevator
+			part = FSfighterJetRudder
+			part = B9_Aero_Wing_Procedural_TypeB
+			part = B9_Aero_Wing_Procedural_TypeC
+			part = FSwinglet
+			part = FStailWing
 		}
 	}
 	RDNode
@@ -3854,9 +3866,7 @@ TechTree
 			part = mk3FuselageMONO
 			part = RCSTank1-2
 			part = RCSFuelTank
-			part = SXTOMS
 			part = RCSBoonExt
-			part = SXTRCSRack
 			part = SXTVernier885
 			part = HeavyRcs
 			part = LargeOMS
@@ -3872,6 +3882,18 @@ TechTree
 			part = LBSI-ENG-MPt180-HB
 			part = SXTOMS
 			part = SXTVernier885
+			part = SXTRCSRack
+			part = mk3_shuttle_noseCone
+			part = M2X_SCRCS
+			part = M2X_RCSBlister
+			part = M2X_OMSBlister
+			part = M2X_FF5WayRCS
+			part = M2X_PGRCS
+			part = M2X_RCRCS
+			part = SXTRCSRack
+			part = SXTOMS
+			part = M2X_OMSpod
+			part = mk3_OMSystem
 		}
 	}
 	RDNode
@@ -3942,15 +3964,14 @@ TechTree
 			part = tarsierChemCam
 			part = SXTtruckcabinsmall
 			part = SXTtruckmiddleSmall
-			part = SXTtruckrearSmall
 		}
 	}
 	RDNode
 	{
-		id = buoyancy
-		nodepart = Buoyancy
-		title = Basic Bouyancy Compensators
-		description = Time to explore the Oceans of Kerbin_  Or maybe rise above them
+		id = Buoyancy
+		nodepart = Basic Bouyancy Compensators
+		title = Boats
+		description = Time to explore the Oceans of Kerbin - or maybe rise above them
 		cost = 3
 		pos = -1350,1650,-3
 		icon = RDicon_emgineering101
@@ -3966,6 +3987,18 @@ TechTree
 		}
 		Unlocks
 		{
+			part = FSfloatEnd
+			part = FSfloatEndTail
+			part = FSfloatStrut
+			part = FSfloatStraight
+			part = fsmovecraftgadget
+			part = SXTfloatMid
+			part = SXTfloatOutboard
+			part = SXTfloatFront
+			part = HL_AirshipEnvelope_Una
+			part = AirshipCap
+			part = HL_AirshipEnvelope
+			part = ProtoLiftBody
 		}
 	}
 	RDNode
@@ -4002,8 +4035,8 @@ TechTree
 			part = KSCTruckAxleNarrowComplex
 			part = SXTtruckcabin
 			part = KSCTruckAxleWideComplex
-			part = SXTtruckrear
 			part = SXTtruckmiddle
+			part = HL_AirshipEnvelope_Ray
 		}
 	}
 	RDNode
@@ -4141,6 +4174,7 @@ TechTree
 			part = WBI_SD18
 			part = WBI_Adapter
 			part = SXTKOPO4E
+			part = M2X_Short25adapter
 		}
 	}
 	RDNode
@@ -4183,7 +4217,8 @@ TechTree
 			part = WBI_DR18
 			part = SXTdockingPortVeryLarge
 			part = sxtairlockAnimated
-			part = docking-25
+			part = M3X_InlineDockingPort
+			part = M3X_StackDockingPort
 		}
 	}
 	RDNode
@@ -4400,6 +4435,7 @@ TechTree
 			part = USRPWS
 			part = RTGigaDish1
 			part = RTGigaDish2
+			part = HighGainAntenna
 		}
 	}
 	RDNode
@@ -4431,6 +4467,7 @@ TechTree
 			part = km_valve2
 			part = scienceHardDrive
 			part = RSBprobeSaturn
+			part = LprobeFoil
 		}
 	}
 	RDNode
@@ -4468,6 +4505,7 @@ TechTree
 			part = LBSI_ESP-R800-40
 			part = LBSI_DRG-SOLAR-PN01
 			part = WBI_MOLESolarPanel
+			part = M2X_SolarpanelPod
 		}
 	}
 	RDNode
@@ -4534,7 +4572,6 @@ TechTree
 		}
 		Unlocks
 		{
-			part = RATObottle
 			part = FASADeltaCastorSrb
 			part = KWsrbGlobeVI
 			part = KWsrbUllageLarge
@@ -4547,6 +4584,7 @@ TechTree
 			part = RSBdeltaIVsrm
 			part = KA_SRB_625_02
 			part = LBSI-SB-FRT360
+			part = M2X_RATO
 		}
 	}
 	RDNode
@@ -4731,6 +4769,9 @@ TechTree
 			part = SXTPipeShort
 			part = SXTPipeLong
 			part = SXTPipeHub
+			part = M2X_THub
+			part = M2X_XHub
+			part = M2X_Servicebay
 		}
 	}
 	RDNode
@@ -4787,7 +4828,6 @@ TechTree
 		}
 		Unlocks
 		{
-			part = Interceptor Cockpit
 			part = advSascr3
 			part = Sasdv4
 			part = B9_Cockpit_MK1_Control_SAS
@@ -5080,13 +5120,23 @@ TechTree
 			part = mk2Fuselage
 			part = mk2CargoBayS
 			part = KKAOSS_adapter_base_to_MK2_g
-			part = 25mKossak
 			part = SXT25mMk2Adap
 			part = SXT25mMk2AdapSlant
 			part = SXTmk210degree
 			part = SXTmk2225degree
 			part = SXTmk2adaptorIntake
 			part = SXTsmallbicoupleradaptor
+			part = M2X_RootChineAdapter
+			part = M2X_RootChineLong
+			part = M2X_ChineLong
+			part = M2X_HypersonicNose
+			part = Typhoon Cockpit
+			part = SXTEntenteCordiale
+			part = M2X_Precooler
+			part = Interceptor Cockpit
+			part = M2X_UST
+			part = M2X_625tricoupler
+			part = M2X_linearTricoupler
 		}
 	}
 	RDNode
@@ -5114,11 +5164,17 @@ TechTree
 			part = B9_Engine_Jet_Turbojet
 			part = B9_Control_ASAS
 			part = bdMiniJet
-			part = FSturboProp
 			part = NBinstake0m
 			part = NBjetTurbo0m
-			part = MK1CrewCabin
-			part = SXTWingLarge
+			part = SXTradialWindow
+			part = Mk1 S39 Cockpit
+			part = KN2Cabin
+			part = FSbomberFuselageTail
+			part = SXTke111
+			part = FSbomberFuselage
+			part = FSCrewFuselage
+			part = FSbomberCockpit
+			part = FSengineMount
 		}
 	}
 	RDNode
@@ -5283,6 +5339,8 @@ TechTree
 			part = SXTSaturnV3Enginge
 			part = SXTSaturnV3Upper
 			part = SXTsize2to3Adaptor
+			part = M3X_Linearaerospike
+			part = SXTOsualHullLarge
 		}
 	}
 	RDNode
@@ -5318,6 +5376,7 @@ TechTree
 			part = FASAGerminiSRB175_5Seg
 			part = FASAGerminiSRB175
 			part = KA_SRB_125_01
+			part = M2X_RadialAASRB
 		}
 	}
 	RDNode
@@ -5541,6 +5600,7 @@ TechTree
 			part = B9_Aero_Intake_RNM
 			part = deltaWing
 			part = sweptWing
+			part = SXTengineattachment2
 		}
 	}
 	RDNode
@@ -5577,6 +5637,7 @@ TechTree
 			part = SXT375mProbe
 			part = KsatComSmallAlt
 			part = SXT375mProbe
+			part = M3XDroneCore
 		}
 	}
 	RDNode
@@ -5618,6 +5679,7 @@ TechTree
 			part = ArcjetLinearRcs
 			part = microwaveReceiver_micro
 			part = CatalyticEngineR
+			part = M2X_IonEngine
 		}
 	}
 	RDNode
@@ -5701,6 +5763,13 @@ TechTree
 			part = IR_RotatronVTOLScaleable
 			part = KER_VTOL
 			part = SXTVTOLturboFan
+			part = M2X_Jumpjet
+			part = M2X_FuselageRVTOLE
+			part = M2X_Pegasus
+			part = M2X_Siddeley
+			part = M2X_HeavyVTOL
+			part = M2X_LiftFan
+			part = M2X_FuselageLiftFan
 		}
 	}
 	RDNode
@@ -5779,8 +5848,25 @@ TechTree
 			part = SXTmk3Cockpit52
 			part = LMkIIIAircaftFus
 			part = LMkIIIAircaftFusLong
-			part = SXTWingVeryLarge
 			part = SXT25to375mKossak
+			part = M3X_EndChine
+			part = M3X_ShortChine
+			part = SXTWingLarge
+			part = SXTWingLarge
+			part = M3X_AdapterSegment
+			part = M3X_ShortSegment
+			part = M3X_EndSegment
+			part = M3X_nosecap
+			part = M3X_CrewSegment
+			part = M3X_AttachSegment
+			part = M3X_size1adapter
+			part = M3X_Tricoupler
+			part = M3X_Quadcoupler
+			part = M3X_OMSShoulder
+			part = M3X_InverterAdaptermk2
+			part = M3Xdecoupler
+			part = mk3Cockpit_Airliner
+			part = SXTOsualTailLarge
 		}
 	}
 	RDNode
@@ -5972,6 +6058,7 @@ TechTree
 			part = RSBtankDeltaIVdcss4m
 			part = WBI_QuadEngineCoupler
 			part = WBI_TitanII-64
+			part = M3X_ConcentricAerospike
 		}
 	}
 	RDNode
@@ -6150,7 +6237,6 @@ TechTree
 			part = nuclearEngineLANTR
 			part = nuclearEngineLightbulb
 			part = USI_ORIONTank
-			part = SXTNERVA
 		}
 	}
 	RDNode
@@ -6521,6 +6607,7 @@ TechTree
 			part = orbitalEngine-375
 			part = SXTKDBTsar3
 			part = SXTK1BaseLarge
+			part = SXTKDBTsar2
 		}
 	}
 	RDNode
@@ -6782,6 +6869,7 @@ TechTree
 			part = DUMBO_Mk1
 			part = SXTNERVA
 			part = SXTNERVAB
+			part = M2X_AtomicJet
 		}
 	}
 	RDNode
@@ -6812,6 +6900,8 @@ TechTree
 			part = DustyPlasmaMk2
 			part = DustyPlasmaMk2
 			part = DustyPlasmaMk2
+			part = M3X_Hades
+			part = M3X_NuclearJet
 		}
 	}
 	RDNode
@@ -6835,89 +6925,7 @@ TechTree
 		}
 		Unlocks
 		{
-			part = RLA_small_LFO_tank4
-			part = RLA_small_LFO_tank1
-			part = SXTmk3CargoBayRamp
-			part = SXTKe90TurboJet
-			part = SXTBalloon375
-			part = SXTMTVGirderOpenSmall
-			part = SXTMTVGirderOpen
-			part = SXTMTVGirderBasic
-			part = SXTMTVGirder
-			part = SXTBalloonGoldB
-			part = SXTBalloonGold
-			part = LMkIIAircaftFusLong
-			part = LMkIIAircaftFus
-			part = SXTSmallFuselage
-			part = FNFissionFusionCatReactorMk1
-			part = FNFissionFusionCatReactorMk1
-			part = GasCoreReactorMk2
-			part = DustyPlasmaMk2
-			part = PotatoRoid
-			part = cl_large_nuclearEngine
-			part = RLA_mp_tiny_stack
-			part = RLA_mp_tiny_radial
-			part = RLA_mp_small_stack
-			part = SXTKDBTsar2
-			part = SXTBalloonGoldB375
-			part = liquidEngineMiniTurbo
-			part = NuclearForgeCore
-			part = LBSIfuelGENStack
-			part = InflatableHAB
-			part = LBSIfuelGENRadial
-			part = LBSIElecGENStack
-			part = LBSIElecGENRadial
-			part = SXTwheelbaseSmall
-			part = SXTwheelbase
-			part = SXTtruckbox
-			part = MK1Cargobay
-			part = MKS_LightGlobe
-			part = SmallGearBay
-			part = SXTradialWindow
-			part = MKS_LandingWheel_Side
-			part = MKS_LandingLeg
-			part = BAEprobe10m
-			part = SYprobe7m
-			part = BAEprobe7m
-			part = SYprobe5m
-			part = SYprobe3m
-			part = BAEprobe5m
-			part = WBI_fairingSize18
-			part = LRadialAirIntake
-			part = SXTfairingSize0
-			part = LBSI_AFA500-2
-			part = WBI_titanNoseCone
-			part = SXTHeatShieldSize0
-			part = sxtshroudradialhardpoint
-			part = SXTMk2FuselageStructural
-			part = SXTengineattachment2
-			part = SXTengineattachment
-			part = adapter-125-0625-2
-			part = truss-hex-03
-			part = truss-octo-03
-			part = adapter-125-0625-3
-			part = adapter-125-0625-4
-			part = truss-hex-02
-			part = adapter-25-125
-			part = truss-hex-adapter-01
-			part = truss-hex-01
-			part = truss-octo-02
-			part = adapter-25-multi-01
-			part = truss-octo-adapter-01
-			part = truss-octo-adapter-crew-01
-			part = adapter-rad-0625
-			part = truss-octo-01
-			part = truss-octo-hub-01
-			part = truss-octo-attach-01
-			part = truss-octo-crew-03
-			part = truss-octo-crew-02
-			part = adapter-rad-125
-			part = truss-octo-crew-01
-			part = truss-octo-hub-crew-01
-			part = adapter-375-25
-			part = truss-octo-docking-125
-			part = truss-octo-docking-25
-			part = truss-octo-docking-octo
+			part = HL_AirshipEnvelope_Cirrus
 		}
 	}
 	RDNode
@@ -6958,6 +6966,9 @@ TechTree
 			part = NP_OdinDockAdapt
 			part = crewtube-airlock-25
 			part = MKV_Airlock
+			part = M2X_Endcap
+			part = M2X_AligningDockingPort
+			part = M2X_ShieldedDockingPort
 		}
 	}
 	RDNode
@@ -7014,6 +7025,9 @@ TechTree
 			part = SXTelevonSmall
 			part = SXTelevonSmallHalf
 			part = SXTAirbrake
+			part = FSbiPlaneAileron
+			part = FSbiPlaneElevator
+			part = FSbiPlaneRudder
 		}
 	}
 	RDNode
@@ -7069,10 +7083,10 @@ TechTree
 		Unlocks
 		{
 			part = NB0mtankJet2
-			part = SXTTinyprop
 			part = 625mBonny
-			part = SXTClyde
 			part = LMiniAircaftTail
+			part = miniFuselage
+			part = SXTSmallFuselage
 		}
 	}
 	RDNode
@@ -7103,6 +7117,9 @@ TechTree
 			part = delta_small
 			part = wingConnector4
 			part = SXTWingTipRound
+			part = SXTWingSmallHalf
+			part = SXTWingSmall
+			part = FSfighterWing
 		}
 	}
 	RDNode
@@ -7126,8 +7143,9 @@ TechTree
 		}
 		Unlocks
 		{
-			part = JetEngine
 			part = SXTMiniJet
+			part = FSoblongTailJet
+			part = JetEngine
 		}
 	}
 	RDNode
@@ -7152,6 +7170,9 @@ TechTree
 		Unlocks
 		{
 			part = turboJet
+			part = MiniTurbojetPod
+			part = M2X_Turbofan
+			part = M2X_SCRamjet
 		}
 	}
 	RDNode
@@ -7205,6 +7226,8 @@ TechTree
 		Unlocks
 		{
 			part = turboFanEngine
+			part = M2X_Ramjet
+			part = M2X_Turbojet
 		}
 	}
 	RDNode
@@ -7235,6 +7258,9 @@ TechTree
 		Unlocks
 		{
 			part = turboFanSize2
+			part = M3X_Turbofan
+			part = M3X_XLTurbofan
+			part = M3X_TurboJet
 		}
 	}
 	RDNode
@@ -7263,6 +7289,11 @@ TechTree
 			part = B9_Engine_SABRE_Intake_M
 			part = SXTRadialAirIntakeShockCone
 			part = SXTshockConeIntakeSize2
+			part = SXTInlineAirIntakeTLarge
+			part = M3X_IntakeSegment
+			part = M3X_ConeIntake
+			part = M2X_circularintake
+			part = M2X_Shockcone
 		}
 	}
 	RDNode
@@ -7305,6 +7336,12 @@ TechTree
 			part = B9_Cockpit_S2_Adapter
 			part = B9_Cockpit_S2
 			part = B9_Cockpit_S3
+			part = M3X_hypersonicnosecone
+			part = M2X_BladeCockpit
+			part = M2X_RadialMountA
+			part = M2X_RadialMountB
+			part = M2X_SpadeTail
+			part = M2X_InverterFuselage
 		}
 	}
 	RDNode
@@ -7314,20 +7351,18 @@ TechTree
 		title = Advanced Fluid Displacement
 		description = Advanced Fluid Displacement
 		cost = 95
-		pos = -1240,1650,-1
+		pos = -1230,1650,-1
 		icon = RDicon_generic
 		anyParent = True
 		hideEmpty = False
 		hideIfNoBranchParts = False
 		scale = 0.6
-		Parent
-		{
-			parentID = buoyancy
-			lineFrom = RIGHT
-			lineTo = LEFT
-		}
 		Unlocks
 		{
+			part = FSfloatGearbay
+			part = HL_AirshipEnvelope_Dodec
+			part = Blimp
+			part = HL_AirshipEnvelope_Octo
 		}
 	}
 	RDNode
@@ -7340,7 +7375,7 @@ TechTree
 		pos = -1085,1650,-1
 		icon = RDicon_generic
 		anyParent = True
-		hideEmpty = True
+		hideEmpty = False
 		hideIfNoBranchParts = False
 		scale = 0.6
 		Parent
@@ -7351,6 +7386,11 @@ TechTree
 		}
 		Unlocks
 		{
+			part = ProtoLiftHub
+			part = TopMountHub
+			part = DeathStarBattery
+			part = HL_AirshipEnvelope_Cirrus_Real
+			part = HL_AirshipEnvelopeHecto
 		}
 	}
 	RDNode
@@ -7374,9 +7414,12 @@ TechTree
 		}
 		Unlocks
 		{
-			part = SXTKO211prop
 			part = SXTMerlin66prop
 			part = SXTPWPT6
+			part = FSswampEngine
+			part = KAXsportprop
+			part = SXTPWR2800
+			part = FSnoseEngine
 		}
 	}
 	RDNode
@@ -7401,8 +7444,13 @@ TechTree
 		Unlocks
 		{
 			part = SXTNK12M
-			part = SXTPWR2800
 			part = SXTJ213
+			part = M2X_Turboprop
+			part = FSlancasterEngineGear
+			part = FSlancasterEngine
+			part = KAXturboprop
+			part = KAXradialprop
+			part = FSturboProp
 		}
 	}
 	RDNode
@@ -7427,6 +7475,9 @@ TechTree
 		Unlocks
 		{
 			part = SXTeFan
+			part = KAXelectricprop
+			part = FSPROpellerElectric
+			part = FSnoseEngineElectric
 		}
 	}
 }


### PR DESCRIPTION
Includes
-Addition of Insanity's mk2/mk3 expansion pack.
-Mk3 mini expansion
-Hoolgun lab's Airship parts
-Rearangement of Firespitter parts.
And an overal enhancement of the early aviation progression.

HL_AirshipEnvelope_Cirrus is an intended cheat item and as such should not be in the tech tree progression.
