### PR TITLE
Mk0-Lf tank

### DIFF
--- a/GameData/ETT/EngTechTree.cfg
+++ b/GameData/ETT/EngTechTree.cfg
@@ -963,6 +963,7 @@ TechTree
 			part = Mk1FuselageStructural
 			part = SXTTinyprop
 			part = miniJetEngine
+			part = miniFuselage
 		}
 	}
 	RDNode
@@ -7303,7 +7304,6 @@ TechTree
 			part = NB0mtankJet2
 			part = 625mBonny
 			part = LMiniAircaftTail
-			part = miniFuselage
 			part = SXTSmallFuselage
 		}
 	}


### PR DESCRIPTION
-Added squad LF Mk0 tank to aviation. Made no sense to have it in mk0 while all engines and intakes in aviation are 0.645.
