### PR TITLE
SXT Legacy parts removal

### DIFF
--- a/GameData/ETT/EngTechTree.cfg
+++ b/GameData/ETT/EngTechTree.cfg
@@ -1308,7 +1308,6 @@ TechTree
 			part = LFKA_Jet_PropFan_03
 			part = MK1IntakeFuselage
 			part = IntakeRadialLong
-			part = SXTInlineAirIntake
 			part = LRadialAirIntake
 			part = B9_Aero_Intake_DSIX
 			part = B9_Aero_Intake_DSI
@@ -2422,8 +2421,6 @@ TechTree
 			part = LMkIIAircaftTail
 			part = LMkIIIAircaftFus
 			part = LMkIIIAircaftFusLong
-			part = LMkIIAircaftFusLong
-			part = LMkIIAircaftFus
 			part = SXTGoose
 			part = B9_Adapter_SM2
 			part = med2mPodA


### PR DESCRIPTION
-Removed some SXT parts from the tree. These were unable to be addressed by the MM patch and were mostly identical to those in vanilla.
