### PR TITLE
Added Cormorant Aeronology, moved USI Sounding rockets

### DIFF
--- a/GameData/ETT/EngTechTree.cfg
+++ b/GameData/ETT/EngTechTree.cfg
@@ -264,13 +264,6 @@ TechTree
 			part = OrbitalGrapplerJR
 			part = Gemini_Crew_A
 			part = Alnair_LES_A
-			part = Polaris_Crew_A
-			part = Tantares_Crew_A
-			part = Polaris_Orbital_A
-			part = Tantares_Habitation_B
-			part = Alnair_Orbital_A
-			part = LTS05_side
-			part = LTS05_core
 		}
 	}
 	RDNode
@@ -330,7 +323,6 @@ TechTree
 			part = RadialOxygenBig
 			part = Rodan
 			part = Cargo
-			part = kerbalism-oxygen-radial-big
 		}
 	}
 	RDNode
@@ -362,7 +354,6 @@ TechTree
 			part = Lg_DirtDrill
 			part = MK3_Refinery
 			part = MK3_IndustrialSifter
-			part = OrbitalScanner
 		}
 	}
 	RDNode
@@ -912,6 +903,8 @@ TechTree
 			part = a_6m_cargo
 			part = a_cockpit_adaptor
 			part = B9_Cockpit_MK5
+			part = Airlock
+			part = ShuttleTruss
 		}
 	}
 	RDNode
@@ -1010,8 +1003,6 @@ TechTree
 			part = FS_BiplaneTailFuselage
 			part = SeatHDCommand
 			part = FS_BiplaneSkid
-			part = JuniorFuselage
-			part = shortboom
 		}
 	}
 	RDNode
@@ -1162,7 +1153,6 @@ TechTree
 			part = Knight_Motor_B
 			part = Knight_Motor_C
 			part = ED125
-			part = Polaris_Engine_A
 		}
 	}
 	RDNode
@@ -1250,7 +1240,6 @@ TechTree
 			part = bluedog_Delta2_LowerMainTank
 			part = bluedog_Delta2_UpperMainTank
 			part = EVAfuelLine
-			part = Castor_Extractor_A
 		}
 	}
 	RDNode
@@ -1296,7 +1285,6 @@ TechTree
 			part = KER_FlatBed
 			part = RadialAtmosphericScoop
 			part = radial_atmospheric_scoop2
-			part = SurveyScanner
 		}
 	}
 	RDNode
@@ -1414,7 +1402,6 @@ TechTree
 			part = rFCircIntake
 			part = M2X_MantaIntake
 			part = wingMountA
-			part = SPPIntakeNosecone
 		}
 	}
 	RDNode
@@ -1490,9 +1477,11 @@ TechTree
 			part = c_6m_tanks
 			part = b_4m_tanks
 			part = b_4m_lab
-			part = AoA.cobraCockpit
-			part = AoA.sixtwofiveNC
-			part = SPPQuintcoupler
+			part = AoA,cobraCockpit
+			part = AoA,sixtwofiveNC
+			part = ShuttleBottomLong
+			part = ShuttleOMSDUO
+			part = NoseCone
 		}
 	}
 	RDNode
@@ -1527,7 +1516,6 @@ TechTree
 			part = noseFwdGear
 			part = wheelGear
 			part = tailRwdGear
-			part = Libra_Leg_A
 		}
 	}
 	RDNode
@@ -1620,8 +1608,7 @@ TechTree
 			part = B9_Cockpit_M27
 			part = Gemini_Crew_B
 			part = bluedog_mercuryLES
-			part = Alnair_Crew_C
-			part = Alnair_Crew_A
+			part = TacFoodContainerLarge
 		}
 	}
 	RDNode
@@ -1723,12 +1710,7 @@ TechTree
 			part = longAntenna
 			part = parachuteRadial
 			part = SR_Battery
-			part = SR_LaunchStick
-			part = SR_Nosecone_35
 			part = SR_PackChute_35
-			part = SR_Payload_04
-			part = SR_ProbeCore
-			part = SR_Wing_03
 			part = sepMotor1
 			part = adapterSmallMiniShort
 			part = trussPiece1x
@@ -1785,6 +1767,11 @@ TechTree
 			part = SR_Rocket_35_02
 			part = SR_Wing_02
 			part = SXTWaxWing
+			part = SR_LaunchStick
+			part = SR_Payload_04
+			part = SR_Wing_03
+			part = SR_Nosecone_35
+			part = SR_ProbeCore
 		}
 	}
 	RDNode
@@ -1882,6 +1869,7 @@ TechTree
 			part = FSfighterTailGear
 			part = FSbiplaneGear
 			part = FSfighterLandingGear
+			part = FSbiPlaneWheelPair
 			part = landingFrame
 			part = FS_BiplaneWheel
 		}
@@ -1955,6 +1943,7 @@ TechTree
 			part = MedLadderUtility
 			part = SMLadderUtility
 			part = LGLadderUtility
+			part = SXTlaunchclamp1
 			part = girderAdapterL
 			part = girderAdapterT
 			part = girderAdapterX
@@ -1990,8 +1979,8 @@ TechTree
 			part = Tower Base
 			part = Tower Slice
 			part = Umbilical2
+			part = Stock_pad
 			part = Support
-			part = weight_100kg
 		}
 	}
 	RDNode
@@ -2047,13 +2036,6 @@ TechTree
 			part = DERP_StowBag
 			part = bluedog_veneraProbe
 			part = Gemini_Parachute_A
-			part = Almach_Parachute_A
-			part = Tantares_Parachute_A
-			part = Alnair_Parachute_B
-			part = Alnair_Parachute_A
-			part = SegmentChuteBase
-			part = SegmentChute_drogue
-			part = SegmentChute_1
 		}
 	}
 	RDNode
@@ -2261,7 +2243,8 @@ TechTree
 			part = HeatShield0
 			part = foldingRadSmall
 			part = radPanelSm
-			part = 1.25_Heatshield
+			part = 1,25_Heatshield
+			part = B9_Engine_SABRE_S_Body
 			part = SXTHeatShieldSize0
 			part = RadialRadiatorzzz
 			part = circradiatorKT
@@ -2370,11 +2353,6 @@ TechTree
 			part = Hedgehog
 			part = Arrow_Control_A
 			part = Knight_Control_A
-			part = Hamal_Control_B
-			part = Hamal_Control_D
-			part = Fomalhaut_Control_A
-			part = Pollux_Control_A
-			part = Crater_Control
 		}
 	}
 	RDNode
@@ -2509,9 +2487,6 @@ TechTree
 			part = indicatorLightSmall
 			part = hc_wideangle
 			part = hc_launchcam
-			part = Tantares_Light_A
-			part = Hamal_Battery_A
-			part = Vostok_Service_A
 		}
 	}
 	RDNode
@@ -2535,6 +2510,7 @@ TechTree
 		}
 		Unlocks
 		{
+			part = SR_Gridfin_03
 			part = SXTKO211Dprop
 			part = SXTKO211prop
 			part = FSPROpeller
@@ -2582,9 +2558,6 @@ TechTree
 			part = opt_winglet_1b
 			part = opt_winglet_1c
 			part = opt_wing_1a
-			part = ProceduralwingBac9
-			part = Proceduralwing2
-			part = Proceduralwing2EndPiece
 		}
 	}
 	RDNode
@@ -2681,8 +2654,6 @@ TechTree
 			part = smallRadialDecoupler
 			part = US_1R210_Wedge_Liquidfuel
 			part = adapter-rad-0625
-			part = AeroBlister
-			part = AeroBlisterDecoupler
 		}
 	}
 	RDNode
@@ -2737,6 +2708,7 @@ TechTree
 			part = SmallStripLight
 			part = SXTFuel625m
 			part = SR_Adapter
+			part = SR_Aerospike
 			part = SR_Decoupler
 			part = SR_Nosecone_625
 			part = SR_PayloadFairing_625
@@ -2747,7 +2719,6 @@ TechTree
 			part = hc_navcam
 			part = bluedog_loEngine
 			part = bluedog_stackVernier
-			part = InlineChute_1t
 		}
 	}
 	RDNode
@@ -2775,6 +2746,7 @@ TechTree
 			part = FASAUmbilicalTower
 			part = launchClamp1
 			part = SYclamp2
+			part = SXTlaunchclamp1
 			part = RSBclamp01
 			part = RSBclamp02
 			part = RSBtowerDelta
@@ -2785,9 +2757,6 @@ TechTree
 			part = Tower Slice 3
 			part = Umbilical
 			part = Umbilical3
-			part = Stock_pad
-			part = SXTlaunchclamp1
-			part = SXTlaunchclamp1
 		}
 	}
 	RDNode
@@ -2829,8 +2798,6 @@ TechTree
 			part = bluedog_malhenaSolar
 			part = Pollux_Solar_A
 			part = Agena_Solar_A
-			part = Alnair_Solar_B
-			part = rover_s_panel0
 		}
 	}
 	RDNode
@@ -3153,7 +3120,6 @@ TechTree
 			part = aerocam
 			part = bahaFlirBall
 			part = bahaCamPod
-			part = LED_headlight
 		}
 	}
 	RDNode
@@ -3191,10 +3157,6 @@ TechTree
 			part = WBI_Mk1DockingPort
 			part = Gemini_Port_A
 			part = bluedog_agenaPort
-			part = Tantares_Port_B
-			part = Tantares_Port_A
-			part = Agena_Port_A
-			part = Tantares_Apas_C
 		}
 	}
 	RDNode
@@ -3231,10 +3193,6 @@ TechTree
 			part = parachuteDrogue
 			part = Chute-SC160Duna
 			part = Chute-NKVDCV
-			part = Alnair_LK_Parachute_A
-			part = Polaris_Port_A
-			part = SegmentChute_2
-			part = SegmentChute_5t
 		}
 	}
 	RDNode
@@ -3271,7 +3229,6 @@ TechTree
 			part = SXTn1GridFin
 			part = Gridfin
 			part = gridfin
-			part = SR_Gridfin_03
 		}
 	}
 	RDNode
@@ -3335,6 +3292,7 @@ TechTree
 			part = mediumDishAntenna
 			part = microwaveReceiver
 			part = microwaveSphereReceiver
+			part = SurveyScanner
 			part = KA_DetectionArray_01
 			part = microwaveTransmitter
 			part = UKS_PowerAntenna
@@ -3609,8 +3567,6 @@ TechTree
 			part = 3m2xPit
 			part = surfCanopy
 			part = M2X_InlineIntake
-			part = SPPWideTricoupler
-			part = SPPSize2coupler
 		}
 	}
 	RDNode
@@ -3662,6 +3618,7 @@ TechTree
 			part = US_1C20_Wedge_Octocore
 			part = SXTPipeGLong
 			part = SXTPipeLong
+			part = SXTmk2225degree
 			part = RSBstrutXL
 			part = kapcub1x05biadapt
 			part = kapcubebicoupler
@@ -3719,15 +3676,6 @@ TechTree
 			part = ringcmdpodMk1001bis
 			part = orbitaiespod
 			part = bluedog_mercuryPod
-			part = Vostok_Crew_A
-			part = Tantares_Habitation_A
-			part = Tantares_Orbital_A
-			part = Hamal_Orbital_A
-			part = Hamal_Orbital_B
-			part = Hamal_Habitation_A
-			part = Hamal_Habitation_B
-			part = Alnair_Crew_B
-			part = Tantares_Orbital_B
 		}
 	}
 	RDNode
@@ -3933,8 +3881,6 @@ TechTree
 			part = LBSI-ENG-LAE-250
 			part = adapter-rad-125
 			part = InterstellarSphereTank
-			part = AeroBlister2
-			part = AeroBlisterDecoupler2
 		}
 	}
 	RDNode
@@ -4011,7 +3957,7 @@ TechTree
 			part = radPanelEdge
 			part = radPanelLg
 			part = microwaveThermalEnergyReceiverS
-			part = 2.5_Heatshield
+			part = 2,5_Heatshield
 			part = SXTcapsuleshield
 			part = radialEngineBody
 			part = WBI_MK85HeatShield
@@ -4023,7 +3969,7 @@ TechTree
 			part = KspiISVradiator
 			part = CargoHeatShield
 			part = SEP_IHP
-			part = Polaris_Heatshield_A
+			part = M2X_Precooler
 		}
 	}
 	RDNode
@@ -4118,7 +4064,8 @@ TechTree
 			part = P3N-65 Virtugenic
 			part = commDish
 			part = phasedArray1
-			part = dmSIGINT.Small
+			part = OrbitalScanner
+			part = dmSIGINT,Small
 			part = LongDeployableAntenna
 			part = yagiActual
 			part = awacsRadar
@@ -4127,7 +4074,6 @@ TechTree
 			part = bluedog_domeAntenna
 			part = bluedog_rangerDish
 			part = Fomalhaut_Antenna_A
-			part = DAS1
 		}
 	}
 	RDNode
@@ -4234,9 +4180,6 @@ TechTree
 			part = SUS_LFO_A
 			part = SUS_Engine_A
 			part = TUS_Engine_A
-			part = WrapperTank
-			part = Polaris_LFO_A
-			part = Alnair_Cargo_A
 		}
 	}
 	RDNode
@@ -4284,11 +4227,9 @@ TechTree
 			part = rectSpoiler
 			part = splitCtrlSrf
 			part = bluedog_Saturn_S1_LargeFin
-			part = AoAero.ADVfin
+			part = AoAero,ADVfin
 			part = angledfin
 			part = TESTFin
-			part = B9_Aero_Wing_ControlSurface_SH_4mProcedural
-			part = ProceduralAllMovingWing
 		}
 	}
 	RDNode
@@ -4354,6 +4295,7 @@ TechTree
 		{
 			part = solarPanelsfa2
 			part = FASASolarMed
+			part = FSpropellerFolding
 			part = solarpanel-curved-375-1
 			part = solarpanel-deploying-1x3-1
 			part = solarpanel-deploying-1x4-1
@@ -4376,15 +4318,6 @@ TechTree
 			part = CargoShorud
 			part = solarPanelsuncat1
 			part = bluedog_MOL_Solar2
-			part = Pheonix_Ex_Solar_A
-			part = Tantares_Solar_A
-			part = Tantares_Solar_B
-			part = Polaris_Solar_A
-			part = Alnair_Solar_A
-			part = Vega_Solar_B
-			part = Alnair_LK_Solar_A
-			part = Tantares_Solar_C
-			part = SP-RR-1
 		}
 	}
 	RDNode
@@ -4487,10 +4420,6 @@ TechTree
 			part = bluedog_MOL_RCS
 			part = Auva_RCS_B
 			part = Auva_RCS_A
-			part = Libra_RCS_A
-			part = Libra_Nesting_A
-			part = Capella_Mono_A
-			part = Capella_Engine_A
 		}
 	}
 	RDNode
@@ -4556,7 +4485,6 @@ TechTree
 			part = SXTtruckcabinsmall
 			part = SXTtruckmiddleSmall
 			part = AKI GolfClub
-			part = RtgRoverBody
 		}
 	}
 	RDNode
@@ -4633,7 +4561,6 @@ TechTree
 			part = KSCTruckAxleWideComplex
 			part = SXTtruckmiddle
 			part = HL_AirshipEnvelope_Ray
-			part = RuggedRoverBody
 		}
 	}
 	RDNode
@@ -4665,7 +4592,6 @@ TechTree
 			part = critterCrawler
 			part = roverWheel3
 			part = KER_Wheel_01
-			part = MRR_rover
 		}
 	}
 	RDNode
@@ -4991,7 +4917,7 @@ TechTree
 			part = bluedog_AtlasV_RD180
 			part = ALV_Engine_A
 			part = ALV_LFO_A
-			part = WrapperTankLong
+			part = OMSEngine
 		}
 	}
 	RDNode
@@ -5058,7 +4984,7 @@ TechTree
 			part = RTGigaDish1
 			part = RTGigaDish2
 			part = HighGainAntenna
-			part = dmSIGINT.End
+			part = dmSIGINT,End
 			part = dmSIGINT
 			part = largeFixedAntenna
 			part = NH_Antenna
@@ -5133,11 +5059,6 @@ TechTree
 			part = LBSI_DRG-SOLAR-PN01
 			part = WBI_MOLESolarPanel
 			part = M2X_SolarpanelPod
-			part = Vega_Solar_C
-			part = Vega_Solar_A
-			part = Vega_Solar_D
-			part = Vega_Solar_E
-			part = SSP_mk1
 		}
 	}
 	RDNode
@@ -5184,11 +5105,6 @@ TechTree
 			part = moduldesspod
 			part = bluedog_Gemini_LanderCan
 			part = bluedog_mercurySRB
-			part = Libra_Crew_A
-			part = Libra_LFO_A
-			part = Libra_Ladder_A
-			part = LTS1_core
-			part = LTS1_side
 		}
 	}
 	RDNode
@@ -5268,7 +5184,7 @@ TechTree
 		id = largeLegs
 		nodepart = largeLegs
 		title = Large Legs
-		description = She's got legs...
+		description = She's got legs,,,
 		cost = 250
 		pos = -810,1755,-5
 		icon = RDicon_landing
@@ -5340,7 +5256,7 @@ TechTree
 			part = HeatShield3
 			part = foldingRadMed
 			part = microwaveThermalEnergyReceiverM
-			part = 3.75_Heatshield
+			part = 3,75_Heatshield
 			part = SmallFNGeneratorMk1
 			part = KspiFoldingRadMed
 			part = KspiWrapAroundRadialRadiatorHalf
@@ -5351,7 +5267,7 @@ TechTree
 			part = RodanHeatShield
 			part = B9_Engine_SABRE_S_Body
 			part = M2X_Precooler
-			part = B9_Engine_SABRE_S_Body
+			part = B9_Engine_SABRE_M_Body
 		}
 	}
 	RDNode
@@ -5427,19 +5343,6 @@ TechTree
 			part = GravityRing
 			part = Hamal_Adapter_A
 			part = Hamal_Adapter_B
-			part = Vega_Crew_E
-			part = Vega_Crew_C
-			part = Vega_Crew_F
-			part = Vega_TrussCrew_A
-			part = Vega_Crew_B
-			part = Alnair_Orbital_B
-			part = Vega_Crew_A
-			part = Vega_Crew_G
-			part = Tantares_DockingCompartment_A
-			part = Tantares_DockingCompartment_B
-			part = hub_5nodes
-			part = hub_6nodes
-			part = hub_8nodes
 		}
 	}
 	RDNode
@@ -5531,7 +5434,6 @@ TechTree
 			part = bluedog_Juno_EngineVernier
 			part = bluedog_Juno_StageRCS
 			part = bluedog_mercuryRCS
-			part = avionicsNoseCone
 		}
 	}
 	RDNode
@@ -5642,8 +5544,6 @@ TechTree
 			part = Ladee_Core
 			part = Rosetta_Core
 			part = Hedgehog
-			part = Agena_Control_A
-			part = Capella_Control_A
 		}
 	}
 	RDNode
@@ -5712,9 +5612,6 @@ TechTree
 			part = Gemini_Service_A
 			part = bluedog_Gemini_MalhenaSM
 			part = Phoenix_Ex_Engine_A
-			part = Tantares_Engine_A
-			part = Hamal_Control_A
-			part = Hamal_Control_C
 		}
 	}
 	RDNode
@@ -5841,12 +5738,8 @@ TechTree
 			part = B9_Body_Mk2_Cargo_Bay_2m
 			part = SXTmk2225degree
 			part = mkX31Pit
-			part = AoA.Hornet
+			part = AoA,Hornet
 			part = mk23_cockpit
-			part = SPPBeak
-			part = SXTmk2225degree
-			part = SPPTricoupler
-			part = SPPQuadcoupler
 		}
 	}
 	RDNode
@@ -5952,8 +5845,6 @@ TechTree
 			part = Ladee_Body
 			part = ED051
 			part = bluedog_DeltaK_AJ10
-			part = toroidalAerospikeSmall
-			part = SR_Aerospike
 		}
 	}
 	RDNode
@@ -5988,6 +5879,7 @@ TechTree
 			part = RLA_small_probe_QBE_gold
 			part = KsatComSmall
 			part = SXTAlouetteI
+			part = b_4m_drone
 			part = truss-octo-drone-01
 			part = DronePod
 			part = helperDrone
@@ -5995,8 +5887,7 @@ TechTree
 			part = B9_Cockpit_D25
 			part = rfProbeCoreSmall
 			part = rfProbeCoreSmallB
-			part = dskycrane_mk1
-			part = AoA.droneTwo
+			part = AoA,falkenTwo
 		}
 	}
 	RDNode
@@ -6255,8 +6146,6 @@ TechTree
 			part = MEMLander
 			part = SXTLander
 			part = M2X_DropshipCockpit
-			part = LTS2_bottom
-			part = LTS2_core
 		}
 	}
 	RDNode
@@ -6292,7 +6181,6 @@ TechTree
 			part = KspiRadiatorConformal
 			part = KspiWrapAroundRadialRadiator
 			part = LargeFlatRadiator
-			part = B9_Engine_SABRE_M_Body
 			part = B9_Engine_SABRE_M_Body
 		}
 	}
@@ -6362,8 +6250,6 @@ TechTree
 			part = opt_wing_a
 			part = opt_winglet_a
 			part = NBpylonAero1
-			part = Proceduralwing4
-			part = ProceduralwingSPP
 		}
 	}
 	RDNode
@@ -6394,6 +6280,7 @@ TechTree
 			part = FASAICBMProbe
 			part = NBprobeRadial2
 			part = KKAOSS_Automatic_Control_g
+			part = avionicsNoseCone
 			part = mk2DroneCore
 			part = probeStackLarge
 			part = SXT375mProbe
@@ -6411,11 +6298,8 @@ TechTree
 			part = helperDrone
 			part = probeStackSmall
 			part = mk3HypersonicDroneCore
-			part = AoA.falkenDroneS
-			part = SPPDroneNosecone
-			part = dskycrane_mk2
-			part = AoA.falkenTwo
-			part = b_4m_drone
+			part = AoA,falkenDroneS
+			part = AoA,droneTwo
 		}
 	}
 	RDNode
@@ -6496,6 +6380,8 @@ TechTree
 			part = US_3R310_EVA_EVAX
 			part = KER_CrewCab
 			part = EVAstrutline
+			part = MMUrack
+			part = CAMMU
 		}
 	}
 	RDNode
@@ -6579,8 +6465,6 @@ TechTree
 			part = habtech_SAW
 			part = LBSI_ESP-R880-SXL
 			part = SXTsolarPanelLarge
-			part = SSP_mk1_125
-			part = SSP_mk2
 		}
 	}
 	RDNode
@@ -6660,10 +6544,6 @@ TechTree
 			part = med2mCargoTopOpen
 			part = med2mTankLong
 			part = med2mSciLab
-			part = mk3Cockpit_Airliner
-			part = mk3_shuttle_noseCone
-			part = mk3Cockpit_Airliner
-			part = mk3_shuttle_noseCone
 		}
 	}
 	RDNode
@@ -6924,7 +6804,6 @@ TechTree
 			part = SCANsat_Scanner32
 			part = tarsierAdvSpaceTelescope
 			part = KsatInstrument
-			part = soil_sampler
 		}
 	}
 	RDNode
@@ -7047,7 +6926,6 @@ TechTree
 			part = ntr-sc-125-2
 			part = ntr-sc-25-1
 			part = engineOnArm
-			part = Castor_Nerva
 		}
 	}
 	RDNode
@@ -7844,7 +7722,6 @@ TechTree
 			part = FSbiPlaneAileron
 			part = FSbiPlaneElevator
 			part = FSbiPlaneRudder
-			part = FSbiPlaneWheelPair
 		}
 	}
 	RDNode
@@ -7892,12 +7769,6 @@ TechTree
 			part = bluedog_MOL_DockingPort
 			part = RFlateralPort
 			part = surfPortJr
-			part = Tantares_DockingMechanism_A
-			part = Tantares_DockingMechanism_B
-			part = Tantares_DockingMechanism_Y
-			part = Tantares_DockingMechanism_Z
-			part = Tantares_Apas_A
-			part = Tantares_Apas_B
 		}
 	}
 	RDNode
@@ -7968,7 +7839,6 @@ TechTree
 			part = FSbiPlaneRudder
 			part = bluedog_redstoneCS
 			part = bluedog_Saturn_S1_SmallFin
-			part = pCtrlSrf1
 		}
 	}
 	RDNode
@@ -8005,6 +7875,7 @@ TechTree
 			part = opt_winglet_b_elevon
 			part = airbrake1
 			part = B9_Aero_AirBrake_Surface_Large
+			part = BodyFlap
 		}
 	}
 	RDNode
@@ -8099,7 +7970,6 @@ TechTree
 			part = sankerJet
 			part = NBjetBasic0m
 			part = fartJet
-			part = turboFanEngineSmall
 		}
 	}
 	RDNode
@@ -8129,6 +7999,7 @@ TechTree
 			part = M2X_SCRamjet
 			part = B9_Engine_Jet_Turbojet
 			part = B9_Engine_Jet_Pod_Small
+			part = PWR185p
 			part = NBjetTurbo0m
 		}
 	}
@@ -8190,8 +8061,7 @@ TechTree
 			part = M2X_Ramjet
 			part = M2X_Turbojet
 			part = B9_Engine_Jet_Turbofan_F119
-			part = AoA.Mk22Vector
-			part = PWR185p
+			part = AoA,Mk22Vector
 		}
 	}
 	RDNode
@@ -8234,7 +8104,6 @@ TechTree
 			part = Mk3Turbofan
 			part = turboramjet2m
 			part = Scramjet
-			part = turboRamJetj_60
 		}
 	}
 	RDNode
@@ -8325,8 +8194,8 @@ TechTree
 			part = b2_4m_adaptor_variant
 			part = B9_Cockpit_S2_Body_05m
 			part = b_cockpit_qs
-			part = AoA.droneFlirTwo
-			part = AoA.Rafale
+			part = AoA,droneFlirTwo
+			part = AoA,Rafale
 		}
 	}
 	RDNode
@@ -8426,9 +8295,6 @@ TechTree
 			part = KAXsportprop
 			part = SXTPWR2800
 			part = FSnoseEngine
-			part = 109Prop
-			part = fighterProp
-			part = merlin
 		}
 	}
 	RDNode
@@ -8468,7 +8334,6 @@ TechTree
 			part = jeyTew
 			part = r10Bear
 			part = ax16leBaron
-			part = spitfiremerlin
 		}
 	}
 	RDNode
@@ -8496,8 +8361,6 @@ TechTree
 			part = KAXelectricprop
 			part = FSPROpellerElectric
 			part = FSnoseEngineElectric
-			part = lil_buzzer
-			part = FSpropellerFolding
 		}
 	}
 	RDNode
@@ -8544,7 +8407,7 @@ TechTree
 			part = jk_7m_adaptor
 			part = a_2m_bicoupler
 			part = a_adaptor_plate
-			part = AoA.SkuCockpit
+			part = AoA,SkuCockpit
 			part = phoenix_cockpit
 			part = c_8m_cockpit
 			part = c_2m_bicoupler

--- a/GameData/ETT/EngTechTree.cfg
+++ b/GameData/ETT/EngTechTree.cfg
@@ -771,6 +771,9 @@ TechTree
 			part = missileController
 			part = bluedog_Diamant_Diapason
 			part = bluedog_cameraMidTech
+			part = 62cm_BoxSat_ScienceThermomometer_Module
+			part = 62cm_BoxSat_ScienceBarometer_Module
+			part = 62cm_BoxSat_ScienceAccelerometer_Module
 		}
 	}
 	RDNode
@@ -2092,6 +2095,7 @@ TechTree
 			part = bluedog_MOL_rackDish
 			part = bluedog_mariner4Dish
 			part = bluedog_rangerBattery
+			part = 62cm_BoxSat_Fixed_SolarPanel
 		}
 	}
 	RDNode
@@ -2306,6 +2310,8 @@ TechTree
 			part = Vega_Antenna_C
 			part = Tantares_Antenna_A
 			part = Alnair_Antenna_A
+			part = Antenna_Tape1
+			part = Antenna_HingedDish1
 		}
 	}
 	RDNode
@@ -2487,6 +2493,7 @@ TechTree
 			part = indicatorLightSmall
 			part = hc_wideangle
 			part = hc_launchcam
+			part = 62cm_BoxSat_Folding1x3_SolarPanel
 		}
 	}
 	RDNode
@@ -2558,6 +2565,9 @@ TechTree
 			part = opt_winglet_1b
 			part = opt_winglet_1c
 			part = opt_wing_1a
+			part = Proceduralwing2
+			part = Proceduralwing2EndPiece
+			part = Proceduralwing4
 		}
 	}
 	RDNode
@@ -2719,6 +2729,9 @@ TechTree
 			part = hc_navcam
 			part = bluedog_loEngine
 			part = bluedog_stackVernier
+			part = 62cm_BoxSat_LFO_Tank_Module
+			part = 62cm_BoxSat_MP_Tank_Module
+			part = 62cm_BoxSat_Xe_Tank_Module
 		}
 	}
 	RDNode
@@ -3630,6 +3643,7 @@ TechTree
 			part = truss-octo-01
 			part = B9_Structure_P8_Surface
 			part = B9_Structure_P8_Surface_Half
+			part = b_docking_port1
 		}
 	}
 	RDNode
@@ -4230,6 +4244,9 @@ TechTree
 			part = AoAero,ADVfin
 			part = angledfin
 			part = TESTFin
+			part = ProceduralAllMovingWing
+			part = B9_Aero_Wing_ControlSurface_SH_4mProcedural
+			part = pCtrlSrf1
 		}
 	}
 	RDNode
@@ -4270,6 +4287,7 @@ TechTree
 			part = SEP_LRRR
 			part = Telescope
 			part = hc_scicam
+			part = 62cm_BoxSat_ScienceGravioli_Module
 		}
 	}
 	RDNode
@@ -4834,6 +4852,13 @@ TechTree
 			part = OrbitalTugCore
 			part = Philae_Legs
 			part = patriotLauncherTurret
+			part = carmend
+			part = carmendwrist
+			part = carmgrapple
+			part = carmlowerarm
+			part = carmshoulder
+			part = carmupperarm
+			part = carmwrist
 		}
 	}
 	RDNode
@@ -5544,6 +5569,7 @@ TechTree
 			part = Ladee_Core
 			part = Rosetta_Core
 			part = Hedgehog
+			part = 62cm_BoxSat_ProbeCore_Module2
 		}
 	}
 	RDNode
@@ -5845,6 +5871,16 @@ TechTree
 			part = Ladee_Body
 			part = ED051
 			part = bluedog_DeltaK_AJ10
+			part = 62cm_BoxSat_Frame
+			part = 62cm_BoxSat_PayloadFrame
+			part = 62cm_BoxSat_ProbeCore_Module
+			part = Antenna_Tape2
+			part = 62cm_BoxSat_ReactionWheel_Module
+			part = RCS_Tri_Small
+			part = 62cm_BoxSat_Battery_Module
+			part = 62cm_BoxSat_Blank_Module
+			part = 62cm_BoxSat_Hatch
+			part = 62cm_BoxSat_BlowoffHatch
 		}
 	}
 	RDNode
@@ -6250,6 +6286,8 @@ TechTree
 			part = opt_wing_a
 			part = opt_winglet_a
 			part = NBpylonAero1
+			part = ProceduralwingSPP
+			part = ProceduralwingBac9
 		}
 	}
 	RDNode
@@ -6544,6 +6582,11 @@ TechTree
 			part = med2mCargoTopOpen
 			part = med2mTankLong
 			part = med2mSciLab
+			part = b_dropBay_mk2
+			part = B-Drop_Bay_mk1
+			part = bf_adaptor
+			part = bf_cargo_tail
+			part = bf_cargo
 		}
 	}
 	RDNode
@@ -7470,6 +7513,8 @@ TechTree
 			part = KspiWarpDrive
 			part = TweakableAntimatterReactorUpgradeA
 			part = KspiQuantumSingulaityReactor
+			part = USI_WarpDrive
+			part = USI_WarpDrive_625
 		}
 	}
 	RDNode
@@ -7506,6 +7551,8 @@ TechTree
 			part = liquidEngineMiniTurbo
 			part = SYplate1m0mX1
 			part = Ladee_Engine
+			part = 62cm_BoxSat_LFOEngine_PayloadModule
+			part = 62cm_BoxSat_MPEngine_PayloadModule
 		}
 	}
 	RDNode
@@ -8104,6 +8151,7 @@ TechTree
 			part = Mk3Turbofan
 			part = turboramjet2m
 			part = Scramjet
+			part = turboRamJetj_60
 		}
 	}
 	RDNode
@@ -8196,6 +8244,7 @@ TechTree
 			part = b_cockpit_qs
 			part = AoA,droneFlirTwo
 			part = AoA,Rafale
+			part = M2X_LHub
 		}
 	}
 	RDNode


### PR DESCRIPTION
I have Moved USI Sounding rocket parts - Nosecone, and few others from start to Model rockets node, as it makes more sense

Also i have added 
- Cormorant Aeronology: http://forum.kerbalspaceprogram.com/index.php?/topic/119951-cormorant-aeronology-dev-thread/&page=1
- BoxSat:  http://forum.kerbalspaceprogram.com/index.php?/topic/82643-104-boxsat-va02f-updated-09162015/
- USI Alcubierre Warp Drive: http://forum.kerbalspaceprogram.com/index.php?/topic/90899-11-alcubierre-warp-drive-stand-alone-v040/
- Canadarm: http://forum.kerbalspaceprogram.com/index.php?/topic/118906-11x-canadarm-v171-5-june-2016/
- fixed 1 part for Mk2 Extension - Added to Experimental Aerodynamics
