### PR TITLE
Rearranged kOS, RT, Ven's Stock Revamp parts

### DIFF
--- a/GameData/ETT/EngTechTree.cfg
+++ b/GameData/ETT/EngTechTree.cfg
@@ -1962,7 +1962,6 @@ TechTree
 			part = KsatGirderSmall
 			part = KsatGirderRound
 			part = KsatGirderTri
-			part = dmUSAtmosSense
 			part = SXTtruckbox
 			part = AirEnabledKASBoatAnchorIV
 			part = truss-octo-crew-03
@@ -2304,9 +2303,7 @@ TechTree
 			part = RTLongAntenna3
 			part = DTMagnetometer
 			part = KsatDishSmall
-			part = RTShortDish1
 			part = SXTAntenna
-			part = SmallFixedAntenna
 			part = hu6s125
 			part = yagiAntenna
 			part = helixAntenna
@@ -2359,7 +2356,7 @@ TechTree
 			part = probeCoreCube
 			part = probeCoreOcto
 			part = SR_InlineProbe
-			part = kOSMachineRad
+			part = kOSMachine1m
 			part = KsatComRound
 			part = sondex2pod
 			part = novapod
@@ -2986,7 +2983,6 @@ TechTree
 			part = InlineRCS
 			part = InterstellarRcs5block
 			part = InterstellarRcsCorner
-			part = kOSMachine1m
 			part = NP_YMRCSBlockLight
 			part = NP_rcstank_125m
 			part = LBSI_TRc_MNP
@@ -3338,9 +3334,7 @@ TechTree
 			part = KA_DetectionArray_01
 			part = microwaveTransmitter
 			part = UKS_PowerAntenna
-			part = RTLongDish1
 			part = SXTTubeAntenna
-			part = mediumFixedAntenna
 			part = bdRadome1snub
 			part = bdRadome1
 			part = bluedog_LOdish
@@ -4128,6 +4122,8 @@ TechTree
 			part = bluedog_rangerDish
 			part = Fomalhaut_Antenna_A
 			part = DAS1
+			part = SmallFixedAntenna
+			part = mediumFixedAntenna
 		}
 	}
 	RDNode
@@ -5095,6 +5091,7 @@ TechTree
 			part = km_valve2
 			part = scienceHardDrive
 			part = RSBprobeSaturn
+			part = kOSMachineRad
 		}
 	}
 	RDNode
@@ -5943,8 +5940,6 @@ TechTree
 			part = OscarEtank
 			part = SXT625mFuel4
 			part = tankSmallAdapter
-			part = KR-2042
-			part = kOSMachine0m
 			part = C3_RTank_00
 			part = MKV_SaddleTank
 			part = LBSI-ENG-WPt1200-SkyWipe

--- a/GameData/ETT/EngTechTree.cfg
+++ b/GameData/ETT/EngTechTree.cfg
@@ -4124,6 +4124,7 @@ TechTree
 			part = DAS1
 			part = SmallFixedAntenna
 			part = mediumFixedAntenna
+			part = HighGainAntenna
 		}
 	}
 	RDNode
@@ -4517,6 +4518,7 @@ TechTree
 			part = km_smart_alt_low
 			part = km_smart_fuel
 			part = km_smart_time
+			part = KR-2042
 		}
 	}
 	RDNode
@@ -5048,7 +5050,6 @@ TechTree
 			part = dishcomlar1
 			part = Dishomega2g
 			part = Dishpcf
-			part = HighGainAntenna
 			part = rpwsAnt
 			part = USRPWS
 			part = RTGigaDish1
@@ -5250,6 +5251,7 @@ TechTree
 			part = FASAProbeCamera
 			part = KKAOSS_LS_container_fertilizer_small
 			part = sensorAtmosphere
+			part = dmUSAtmosSense
 			part = StnSciExperiment3
 			part = StnSciExperiment4
 			part = tarsierSpaceTelescope


### PR DESCRIPTION
kOS: parts are unlocked by Unmanned Tech, then by successive generations of CPU techs.
RemoteTech and Ven's Stock Revamp antennas: rearranged antennas so that the more powerful ones are unlocked after the less powerful. First LKO-range omni, then Mun & Minmus-range dishes, then transplanetary-range ones.
Also removed DMagic Universal Storage Atmospheric Sensor from General Construction node; it was put there, apparently, by mistake.
