### PR TITLE
9-15 Aviation update

### DIFF
--- a/GameData/ETT/EngTechTree.cfg
+++ b/GameData/ETT/EngTechTree.cfg
@@ -912,6 +912,21 @@ TechTree
 			part = a_6m_cargo
 			part = a_cockpit_adaptor
 			part = B9_Cockpit_MK5
+			part = mk4fuselage-3
+			part = mk4pod-1
+			part = mk4cargo-3
+			part = mk4cargo-drop-3
+			part = mk4fueltank-25-4
+			part = mk4adapter-3
+			part = mk4tail-1
+			part = j_2m_bicoupler
+			part = mk2j_adaptor
+			part = j_4m_tanks
+			part = ij_4m_adaptor_variant
+			part = ij_adaptor
+			part = mk3_shuttle_noseCone
+			part = rect4M
+			part = rect4mTpr
 		}
 	}
 	RDNode
@@ -1000,7 +1015,6 @@ TechTree
 			part = SXTTinyprop
 			part = miniJetEngine
 			part = FSbiPlaneSkid
-			part = pdtacJet
 			part = FS_BiplaneWingCenter
 			part = FS_BiplaneWingMain
 			part = FS_BiplaneWingRound
@@ -1334,6 +1348,11 @@ TechTree
 			part = M2X_ESTOC
 			part = M2X_MATTOCK
 			part = M3X_CLEAVER
+			part = mk4vtol-0625-1
+			part = mk4multimodal-125-1
+			part = mk4multimodal-25-2
+			part = mk4multimodal-25-1
+			part = AAengine
 		}
 	}
 	RDNode
@@ -1369,6 +1388,7 @@ TechTree
 			part = opt_winglet_b
 			part = opt_wing_b
 			part = NBpylonAero2
+			part = Proceduralwing4
 		}
 	}
 	RDNode
@@ -1415,6 +1435,7 @@ TechTree
 			part = M2X_MantaIntake
 			part = wingMountA
 			part = SPPIntakeNosecone
+			part = mk2_ramIntake
 		}
 	}
 	RDNode
@@ -1493,6 +1514,22 @@ TechTree
 			part = AoA.cobraCockpit
 			part = AoA.sixtwofiveNC
 			part = SPPQuintcoupler
+			part = mk4fuselage-2
+			part = mk4pod-2
+			part = mk4nose
+			part = mk4cockpit-shoulder-1
+			part = mk4cargo-2
+			part = mk4cargo-drop-2
+			part = mk4crewcabin-1
+			part = mk4servicebay-1
+			part = mk4fueltank-25-3
+			part = mk4fueltank-25-2
+			part = mk4adapter-1
+			part = mk4adapter-2
+			part = mk4tail-2
+			part = mk23_cockpit
+			part = j_4m_lab
+			part = mk4cockpit-1
 		}
 	}
 	RDNode
@@ -1696,6 +1733,7 @@ TechTree
 			part = SYheatShield7m
 			part = KspLongFixedRadiator
 			part = KspiFoldingRadLarge
+			part = mk4enginecooler-25-1
 		}
 	}
 	RDNode
@@ -1832,14 +1870,8 @@ TechTree
 			part = FSoblongMultiTank
 			part = MK1CrewCabin
 			part = InlinePassengerCan
-			part = 1mSharpCone
-			part = rectCkPit
-			part = structBoom
-			part = rect1m
-			part = rect1mAdptr
-			part = rect2mAdptr
-			part = rect2m
 			part = FS_OblongToRoundAdapter
+			part = shortboomb
 		}
 	}
 	RDNode
@@ -2539,6 +2571,8 @@ TechTree
 			part = SXTKO211prop
 			part = FSPROpeller
 			part = FS_BiplaneEngine
+			part = fokkerprop
+			part = spadprop
 		}
 	}
 	RDNode
@@ -2585,6 +2619,9 @@ TechTree
 			part = ProceduralwingBac9
 			part = Proceduralwing2
 			part = Proceduralwing2EndPiece
+			part = B9_Aero_Wing_Procedural_TypeA
+			part = B9_Aero_Wing_Procedural_TypeD
+			part = ProceduralwingBac9
 		}
 	}
 	RDNode
@@ -2643,6 +2680,11 @@ TechTree
 			part = med2mAdapter
 			part = med2mTankShort
 			part = med2mCrew
+			part = rect1m
+			part = rect2mTpr
+			part = rect1mAdptr
+			part = rect2mAdptr
+			part = structBoom
 		}
 	}
 	RDNode
@@ -3606,11 +3648,12 @@ TechTree
 			part = B9_Body_Mk1_Fuselage_400m
 			part = B9_Body_Mk1_Cargo_Bay_100m
 			part = B9_Body_Mk1_Cargo_Bay_200m
-			part = 3m2xPit
-			part = surfCanopy
 			part = M2X_InlineIntake
 			part = SPPWideTricoupler
 			part = SPPSize2coupler
+			part = rectCkPit
+			part = surfCkPit
+			part = 1mSharpCone
 		}
 	}
 	RDNode
@@ -4056,6 +4099,10 @@ TechTree
 			part = KAXkueyEngine
 			part = KAXkueyTailRotor
 			part = SXTmeadowlark
+			part = KRXHeronEngine
+			part = KRXSparrowEngine
+			part = KRXSparrowEngineReverse
+			part = KRXSparrowTail
 		}
 	}
 	RDNode
@@ -4289,6 +4336,11 @@ TechTree
 			part = TESTFin
 			part = B9_Aero_Wing_ControlSurface_SH_4mProcedural
 			part = ProceduralAllMovingWing
+			part = B9_Aero_Wing_Procedural_TypeB
+			part = B9_Aero_Wing_Procedural_TypeC
+			part = pCtrlSrf1
+			part = B9_Aero_Wing_ControlSurface_SH_4mProcedural
+			part = ProceduralwingSPP
 		}
 	}
 	RDNode
@@ -4491,6 +4543,9 @@ TechTree
 			part = Libra_Nesting_A
 			part = Capella_Mono_A
 			part = Capella_Engine_A
+			part = mk4rcsblister-2
+			part = mk4rcsblister-1
+			part = mk4cockpit-shoulder-2
 		}
 	}
 	RDNode
@@ -4521,6 +4576,7 @@ TechTree
 			part = km_smart_alt_low
 			part = km_smart_fuel
 			part = km_smart_time
+			part = km_smart_speed
 		}
 	}
 	RDNode
@@ -4825,6 +4881,8 @@ TechTree
 			part = docking-25
 			part = truss-octo-docking-25
 			part = b_docking_port
+			part = j_docking_port
+			part = mk4nose-docking
 			part = j_docking_port
 		}
 	}
@@ -5751,6 +5809,7 @@ TechTree
 			part = IRPistonScaleable
 			part = TelescopeFullAScaleable
 			part = B9_Aero_HL_Body_Cargo_Tail_Wide
+			part = mk4cargotail-1
 		}
 	}
 	RDNode
@@ -5840,7 +5899,6 @@ TechTree
 			part = B9_Body_Mk2_Cargo_Bay_1m
 			part = B9_Body_Mk2_Cargo_Bay_2m
 			part = SXTmk2225degree
-			part = mkX31Pit
 			part = AoA.Hornet
 			part = mk23_cockpit
 			part = SPPBeak
@@ -5887,15 +5945,6 @@ TechTree
 			part = B9_Cockpit_MK2_Nosecone_ASAS
 			part = B9_Aero_Intake_Mount
 			part = B9_Body_Mk1_Cargo_Bay_050m
-			part = wingMountB
-			part = surfCkPit
-			part = rectFlyPit
-			part = RF2mCargoBay
-			part = 1mBicouplerSmall
-			part = rect2mTpr
-			part = 2mHoodAdpter
-			part = rect4M
-			part = rect4mTpr
 		}
 	}
 	RDNode
@@ -6364,6 +6413,11 @@ TechTree
 			part = NBpylonAero1
 			part = Proceduralwing4
 			part = ProceduralwingSPP
+			part = wingMountB
+			part = B9_Aero_Wing_Procedural_TypeD
+			part = B9_Aero_Wing_Procedural_TypeA
+			part = Proceduralwing2
+			part = Proceduralwing2EndPiece
 		}
 	}
 	RDNode
@@ -6416,6 +6470,8 @@ TechTree
 			part = dskycrane_mk2
 			part = AoA.falkenTwo
 			part = b_4m_drone
+			part = mk4drone-1
+			part = j_4m_drone
 		}
 	}
 	RDNode
@@ -6546,6 +6602,14 @@ TechTree
 			part = vtolKento
 			part = vtolShoto
 			part = vtolKodachi
+			part = mk4liftfan-25-1
+			part = mk4liftfan-10-1
+			part = mk4liftfan-375-1
+			part = KRXOspreyEngine
+			part = KRXOspreyEngineRev
+			part = KRXSeaGullEngine
+			part = KRXfenestron
+			part = KRXseagullTail
 		}
 	}
 	RDNode
@@ -6664,6 +6728,12 @@ TechTree
 			part = mk3_shuttle_noseCone
 			part = mk3Cockpit_Airliner
 			part = mk3_shuttle_noseCone
+			part = i_4m_cockpit_isp
+			part = mk3Cockpit_Airliner
+			part = 1mBicouplerSmall
+			part = 2mHoodAdpter
+			part = rect2m
+			part = RF2mCargoBay
 		}
 	}
 	RDNode
@@ -6866,6 +6936,7 @@ TechTree
 			part = SYplate3m1mX7
 			part = SYtank3mCone2
 			part = Mk3Aerospike
+			part = j_linear_aerospike
 		}
 	}
 	RDNode
@@ -7564,6 +7635,7 @@ TechTree
 			part = FNFissionFusionCatReactorMk1
 			part = FNFissionFusionCatReactorMk1
 			part = FNFissionFusionCatReactorMk1
+			part = engine_darkDrive
 		}
 	}
 	RDNode
@@ -7969,6 +8041,7 @@ TechTree
 			part = bluedog_redstoneCS
 			part = bluedog_Saturn_S1_SmallFin
 			part = pCtrlSrf1
+			part = ProceduralAllMovingWing
 		}
 	}
 	RDNode
@@ -8005,6 +8078,8 @@ TechTree
 			part = opt_winglet_b_elevon
 			part = airbrake1
 			part = B9_Aero_AirBrake_Surface_Large
+			part = B9_Aero_Wing_Procedural_TypeB
+			part = B9_Aero_Wing_Procedural_TypeC
 		}
 	}
 	RDNode
@@ -8100,6 +8175,7 @@ TechTree
 			part = NBjetBasic0m
 			part = fartJet
 			part = turboFanEngineSmall
+			part = pdtacJet
 		}
 	}
 	RDNode
@@ -8192,6 +8268,7 @@ TechTree
 			part = B9_Engine_Jet_Turbofan_F119
 			part = AoA.Mk22Vector
 			part = PWR185p
+			part = mk4propfan-125-1
 		}
 	}
 	RDNode
@@ -8235,6 +8312,9 @@ TechTree
 			part = turboramjet2m
 			part = Scramjet
 			part = turboRamJetj_60
+			part = mk4turbofan-25-1
+			part = mk4turbofan-25-2
+			part = mk4turbojet-25-1
 		}
 	}
 	RDNode
@@ -8275,6 +8355,13 @@ TechTree
 			part = Mk3RadialRAMIntake
 			part = shockConeTwoM
 			part = Mk3RamIntake
+			part = mk4intake-largeshock
+			part = mk4enginenacelle-25-1
+			part = mk4enginenacelle-25-2
+			part = mk4intake-largecircular
+			part = mk4intake-radial-1
+			part = mk4intake-radial-2
+			part = mk4cockpit-shoulder-3
 		}
 	}
 	RDNode
@@ -8327,6 +8414,12 @@ TechTree
 			part = b_cockpit_qs
 			part = AoA.droneFlirTwo
 			part = AoA.Rafale
+			part = ils_cockpit
+			part = j_cockpit_qs
+			part = opt_mk2_cockpit
+			part = 3m2xPit
+			part = surfCanopy
+			part = rectFlyPit
 		}
 	}
 	RDNode
@@ -8429,6 +8522,8 @@ TechTree
 			part = 109Prop
 			part = fighterProp
 			part = merlin
+			part = zeroprop
+			part = yakprop
 		}
 	}
 	RDNode
@@ -8469,6 +8564,9 @@ TechTree
 			part = r10Bear
 			part = ax16leBaron
 			part = spitfiremerlin
+			part = mk4turboprop-125-1
+			part = chaikaprop
+			part = corsairprop
 		}
 	}
 	RDNode
@@ -8556,6 +8654,24 @@ TechTree
 			part = opt_winglet_c
 			part = opt_wing_c
 			part = B9_Cockpit_S3
+			part = mk4fuselage-1
+			part = mk4cargo-1
+			part = mk4cargo-drop-1
+			part = mk4fueltank-25-1
+			part = mk4tail-3
+			part = jk_3m_adaptor
+			part = jk_7m_adaptor
+			part = k_6m_tanks
+			part = j_cockpit
+			part = k_8m_cockpit
+			part = j_engineMount_4
+			part = j_4m_tail
+			part = k_2m_bicoupler
+			part = j_dropBay
+			part = k_6m_cargoTail
+			part = k_6m_cargo
+			part = mk4cockpit-2
+			part = mkX31Pit
 		}
 	}
 }

--- a/GameData/ETT/EngTechTree.cfg
+++ b/GameData/ETT/EngTechTree.cfg
@@ -1389,6 +1389,8 @@ TechTree
 			part = opt_wing_b
 			part = NBpylonAero2
 			part = Proceduralwing4
+			part = Proceduralwing4
+			part = B9_Aero_Wing_Procedural_TypeA
 		}
 	}
 	RDNode
@@ -1916,6 +1918,7 @@ TechTree
 			part = FSfighterLandingGear
 			part = landingFrame
 			part = FS_BiplaneWheel
+			part = SmallGearBay
 		}
 	}
 	RDNode
@@ -4341,6 +4344,11 @@ TechTree
 			part = pCtrlSrf1
 			part = B9_Aero_Wing_ControlSurface_SH_4mProcedural
 			part = ProceduralwingSPP
+			part = ProceduralAllMovingWing
+			part = pCtrlSrf1
+			part = B9_Aero_Wing_ControlSurface_SH_4mProcedural
+			part = B9_Aero_Wing_Procedural_TypeB
+			part = B9_Aero_Wing_Procedural_TypeB
 		}
 	}
 	RDNode
@@ -5905,6 +5913,7 @@ TechTree
 			part = SXTmk2225degree
 			part = SPPTricoupler
 			part = SPPQuadcoupler
+			part = M2X_LHub
 		}
 	}
 	RDNode
@@ -6418,6 +6427,12 @@ TechTree
 			part = B9_Aero_Wing_Procedural_TypeA
 			part = Proceduralwing2
 			part = Proceduralwing2EndPiece
+			part = ProceduralwingSPP
+			part = ProceduralwingBac9
+			part = Proceduralwing2
+			part = Proceduralwing2EndPiece
+			part = B9_Aero_Wing_Procedural_TypeD
+			part = B9_Aero_Wing_Procedural_TypeA
 		}
 	}
 	RDNode
@@ -7837,7 +7852,6 @@ TechTree
 			part = LBSIElecGENStack
 			part = LBSIElecGENRadial
 			part = MKS_LightGlobe
-			part = SmallGearBay
 			part = MKS_LandingWheel_Side
 			part = MKS_LandingLeg
 			part = BAEprobe10m
@@ -8079,6 +8093,8 @@ TechTree
 			part = airbrake1
 			part = B9_Aero_AirBrake_Surface_Large
 			part = B9_Aero_Wing_Procedural_TypeB
+			part = B9_Aero_Wing_Procedural_TypeC
+			part = B9_Aero_Wing_Procedural_TypeC
 			part = B9_Aero_Wing_Procedural_TypeC
 		}
 	}
@@ -8672,8 +8688,7 @@ TechTree
 			part = k_6m_cargo
 			part = mk4cockpit-2
 			part = mkX31Pit
+			part = mk4cargodoor-inline-1
 		}
 	}
 }
-
-


### PR DESCRIPTION
Updated some aviation mods:
-OPT Spaceplane parts.
-Reordered Retrofuture Parts; namely fuselages that were way too advanced for their node.
-Added Kerbal Rotor Expansion.
-Updated Airplane Plus. Starting WWI era engines still are more powerful than the ones in the 'aviation'node, so were placed in 'subsonic flight'.
-Added Procedural Wings update.
-Added Crzyrndm's update to B9's Procedural wings.

-Added the new Smart Parts trigger.
