### PR TITLE
Far from Kerbin support

### DIFF
--- a/GameData/ETT/EngTechTree.cfg
+++ b/GameData/ETT/EngTechTree.cfg
@@ -746,6 +746,10 @@ TechTree
 			part = kapcubehabitat
 			part = bluedog_MOL_Hab
 			part = Phoenix_Ex_Control_A
+			part = blockAirlock
+			part = collector
+			part = compressor
+			part = blockCorridor
 		}
 	}
 	RDNode
@@ -6496,6 +6500,7 @@ TechTree
 			part = US_3R310_EVA_EVAX
 			part = KER_CrewCab
 			part = EVAstrutline
+			part = STBBackpack
 		}
 	}
 	RDNode


### PR DESCRIPTION
Puts all parts but the backpack under short term habitation. Backpack is under Advanced EVA Tech.