### PR TITLE
Pathfinder Support (Parts Only)

### DIFF
--- a/GameData/ETT/EngTechTree.cfg
+++ b/GameData/ETT/EngTechTree.cfg
@@ -363,6 +363,7 @@ TechTree
 			part = MK3_Refinery
 			part = MK3_IndustrialSifter
 			part = OrbitalScanner
+			part = WBI_Hacienda
 		}
 	}
 	RDNode
@@ -566,6 +567,8 @@ TechTree
 			part = MKV_MountPoint
 			part = LBSI-Kappa-SiGMA-V5
 			part = CRY-2300Freezer
+			part = WBI_Ponderosa
+			part = WBI_Ponderosa2
 		}
 	}
 	RDNode
@@ -596,6 +599,7 @@ TechTree
 			part = KKAOSS_gangway_6_1
 			part = MKS_EL_LaunchPad
 			part = MKS_EL_OrbitalDock
+			part = WBI_Spyglass
 			part = InterstellarParticleAccelerator
 			part = CXA_SleepHabV6-1
 			part = CXA_SleepHabV6-2
@@ -648,6 +652,7 @@ TechTree
 			part = SEP_MAG
 			part = SEP_GRAV
 			part = bluedog_MOL_Lab
+			part = WBI_DocSciLab
 		}
 	}
 	RDNode
@@ -780,6 +785,7 @@ TechTree
 			part = missileController
 			part = bluedog_Diamant_Diapason
 			part = bluedog_cameraMidTech
+			part = WBI_Terrain
 		}
 	}
 	RDNode
@@ -912,6 +918,8 @@ TechTree
 			part = a_6m_cargo
 			part = a_cockpit_adaptor
 			part = B9_Cockpit_MK5
+			part = WBI_MBM
+			part = WBI_Chuckwagon
 		}
 	}
 	RDNode
@@ -1297,6 +1305,7 @@ TechTree
 			part = RadialAtmosphericScoop
 			part = radial_atmospheric_scoop2
 			part = SurveyScanner
+			part = WBI_MiniDrill
 		}
 	}
 	RDNode
@@ -1908,6 +1917,7 @@ TechTree
 		Unlocks
 		{
 			part = kap1x05to05adap
+			part = WBI_GAslight2
 			part = kap1x05to1adap
 			part = kap1x05to125tanker
 			part = kap1x05hood75
@@ -1992,6 +2002,12 @@ TechTree
 			part = Umbilical2
 			part = Support
 			part = weight_100kg
+			part = WBI_Captstone
+			part = WBI_Patio
+			part = WBI_MiniSlab2
+			part = WBI_Swictback
+			part = WBI_Switchback2
+			part = WBI_TunnelExtender
 		}
 	}
 	RDNode
@@ -2110,6 +2126,7 @@ TechTree
 			part = bluedog_MOL_rackDish
 			part = bluedog_mariner4Dish
 			part = bluedog_rangerBattery
+			part = WBI_AKIPowerStrip
 		}
 	}
 	RDNode
@@ -2267,6 +2284,7 @@ TechTree
 			part = circradiatorKT
 			part = SmallFlatRadiator
 			part = Gemini_Heatshield_B
+			part = WBI_SmokePipe
 		}
 	}
 	RDNode
@@ -2831,6 +2849,8 @@ TechTree
 			part = Agena_Solar_A
 			part = Alnair_Solar_B
 			part = rover_s_panel0
+			part = WBI_Poncho
+			part = WBI_Sombrero
 		}
 	}
 	RDNode
@@ -2924,6 +2944,7 @@ TechTree
 			part = bluedog_Titan2_FuelTank1
 			part = bluedog_Titan2_FuelTank3
 			part = bluedog_Titan2_FuelTank2
+			part = WBI_Conestoga
 		}
 	}
 	RDNode
@@ -5064,6 +5085,7 @@ TechTree
 			part = NH_Antenna
 			part = scanLargeRadar
 			part = Vega_Antenna_B
+			part = WBI_Telegraph
 		}
 	}
 	RDNode


### PR DESCRIPTION
Adds the Pathfinder Parts to ETT. However, this does not include Pathfinder configurations for the Ponderosa,Casa,Hacienda, or Doc, as i can not add pathfinder configurations to ETT, but i can provide Pathfinder configuration files to add the configurations to ETT, as configurations for pathfinder parts are handled on pathfinder's end.